### PR TITLE
Change id of container element to avoid ios issue with demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 
-  <div id="app">
+  <div id="app-container">
 
     <loading-bar
       :on-error-done="errorDone"
@@ -46,7 +46,7 @@
 
     let app = new Vue({
 
-      el: "#app",
+      el: "#app-container",
 
       components: {
         LoadingBar: LoadingBar


### PR DESCRIPTION
Fixes #1.
Issue was error
`SyntaxError: Can't create duplicate variable that shadows a global property: 'app'` 
originating from https://html.spec.whatwg.org/#named-access-on-the-window-object
ios 10 screenshot after (previously was exactly in #1)
![image](https://cloud.githubusercontent.com/assets/1506905/21742332/0f3c1c54-d4f5-11e6-8790-4a7a77f685dd.png)
